### PR TITLE
Added new WooCommerce extension to Third Parties.

### DIFF
--- a/third-parties.html
+++ b/third-parties.html
@@ -136,8 +136,8 @@
             <td>For musicians selling downloads</td>
             <td><a href="https://bandcamp.com/help/selling#eu-vat-digital">Initially will help collect information but intending to operate ultimately as a marketplace (so will go into the first list)</a></a></td>
           </tr>
-        </table> 
-       
+        </table>
+
        <h4>APIs and other services</h4>
 
        <p>If you are rolling your own solution or already have systems in place these serices can save you writing a lot of code in order to comply. They may also offer plugins for ecommerce systems or payment providers.</p>
@@ -148,8 +148,8 @@
             <th>Description</th>
             <th>Announcement / further information</th>
           </tr>
-          
-         
+
+
           <tr>
             <td><a href="http://quaderno.io">Quaderno</a></td>
             <td>If you sell using Stripe Quaderno can ensure you charge the correct VAT, issue invoices and provide a report</td>
@@ -170,9 +170,9 @@
             <td>Validate addresses, do address lookups and make the UI of collecting addresses easier</td>
             <td></td>
           </tr>
-        
-        </table> 
-       
+
+        </table>
+
        <h4>Plugins for CMS or ecommerce software</h4>
 
        <table>
@@ -181,8 +181,8 @@
             <th>Description</th>
             <th>Announcement / further information</th>
           </tr>
-          
-         
+
+
             <tr>
             <td><a href="https://ithemes.com/purchase/easy-eu-value-added-taxes-vat-add-on-ithemes-exchange/">Easy EU VAT WordPress Plugin</a></td>
             <td>A Plugin for iThemes Exchange</td>
@@ -213,7 +213,12 @@
             <td>WordPress plugin. Allows you to set buy links differently for visitors from the EU and outside the EU, for VAT purposes. </td>
             <td></td>
           </tr>
-        </table> 
+          <tr>
+            <td><a href="https://marketpress.com/product/woocommerce-eu-vat-checkout/">WooCommerce EU VAT Checkout</a></td>
+            <td>WordPress plugin for WooCommerce. Fixates end prices of downloadable products, recalculates included VAT dynamically for EU countries during cart/checkout. Built upon WooCommerce’s tax classes/rates feature, extendable through WooCommerce API.</td>
+            <td></td>
+          </tr>
+        </table>
 
       </section>
     </div>
@@ -226,7 +231,7 @@
       </footer>
     </div>
 
-    
+
 
   </body>
 </html>


### PR DESCRIPTION
Adds link and description for new WordPress plugin [WooCommerce EU VAT Checkout](https://marketpress.com/product/woocommerce-eu-vat-checkout/) to Third Parties page.
