### PR TITLE
Added link to EU VAT Assistant

### DIFF
--- a/third-parties.html
+++ b/third-parties.html
@@ -223,6 +223,16 @@
             <td>WordPress plugin for WooCommerce. Fixates end prices of downloadable products, recalculates included VAT dynamically for EU countries during cart/checkout. Built upon WooCommerce’s tax classes/rates feature, extendable through WooCommerce API.</td>
             <td></td>
           </tr>
+          <tr>
+             <td><a href="https://wordpress.org/plugins/woocommerce-eu-vat-assistant/">WooCommerce EU VAT Assistant</a></td>
++            <td>WordPress plugin for WooCommerce. Extends the standard WooCommerce sale process and assists in achieving compliance with the new EU VAT regime starting on the 1st of January 2015. It's a fully featured, premium plugin, distributed free of charge.</td>
++            <td><strong>Note</strong>: <a href="http://aelia.co/shop/eu-vat-assistant-woocommerce/">a paid version is also available</a> to anyone who would like to get access to premium support.            
+          </tr>
+          <tr>
+             <td><a href="http://aelia.co/shop/eu-vat-assistant-woocommerce/">WooCommerce EU VAT Assistant - Paid version</a></td>
++            <td>WordPress plugin for WooCommerce. Extends the standard WooCommerce sale process and assists in achieving compliance with the new EU VAT regime starting on the 1st of January 2015. <strong>This paid version includes access to premium support.</strong></td>
++            <td></td>
+          </tr>
         </table>
 
       </section>


### PR DESCRIPTION
The [EU VAT Assistant](https://wordpress.org/plugins/woocommerce-eu-vat-assistant/) is a free, premium plugin that includes all the features needed to achieve compliance with the new EU VAT rules. [A paid version is also available](http://aelia.co/shop/eu-vat-assistant-woocommerce/) and it includes access to premium support.
